### PR TITLE
Publish EC's RSA pubkey on Nostr

### DIFF
--- a/ec/src/main.rs
+++ b/ec/src/main.rs
@@ -64,6 +64,9 @@ async fn main() -> Result<()> {
 
     // 1. Load the keys from PEM files
     let (pk, sk) = load_keys("ec_private.pem", "ec_public.pem")?;
+    let pk_der = pk.to_der()?;
+    // We need to encode the RSA public key in Base64 to publish it on Nostr
+    let pk_der_b64 = general_purpose::STANDARD.encode(&pk_der);
 
     println!("🔑 Electoral Commission Public key: {}", keys.public_key());
 
@@ -87,6 +90,7 @@ async fn main() -> Result<()> {
         ],
         starting_ts,
         duration,
+        pk_der_b64,
     );
     let election = Arc::new(Mutex::new(election));
     // --- Timers to change status automatically ---


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Election details now include the RSA public key for the election commission, visible in election data.
- **Bug Fixes**
  - None.
- **Refactor**
  - None.
- **Tests**
  - Test helpers and formatting updated to support the new RSA public key field.
- **Chores**
  - None.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->